### PR TITLE
sensors: Build DASH and fix permission for lm3533 als

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,14 @@ Put the following snippet in .repo/local_manifests/c6603.xml
 
 <project path="device/sony/lagan" name="device-sony-lagan" groups="device" remote="sony" revision="master" />
 <project path="device/sony/c6603" name="device-sony-c6603" groups="device" remote="sony" revision="master" />
+<project path="vendor/sony/dash" name="DASH.git" groups="device" revision="master" remote="sony" />
 </manifest>
 ```
 
 Download the zip file with vendor binaries from:
 http://developer.sonymobile.com/downloads/tool/software-binaries-for-xperia-z/
 
-In the root of your Android code tree unzip the SW_binaries_for_Xperia_Z_v1.zip,
+In the root of your Android code tree unzip the SW_binaries_for_Xperia_Z_v2.zip,
 you should now have a directory named vendor/sony/lagan and vendor/sony/c6603 in your tree.
 
 * repo sync

--- a/device.mk
+++ b/device.mk
@@ -19,6 +19,7 @@ PRODUCT_PACKAGES += \
     libgps.utils \
     libloc_adapter \
     libloc_eng \
+    sensors.default
 
 PRODUCT_TAGS += dalvik.gc.type-precise
 

--- a/rootdir/ueventd.sony.rc
+++ b/rootdir/ueventd.sony.rc
@@ -76,3 +76,7 @@
 /sys/devices/virtual/input/input*   interval    0640  system   system
 /sys/devices/virtual/input/input*   registers   0640  system   system
 /sys/devices/virtual/input/input*   single      0640  system   system
+
+# LM3533 ALS
+/sys/devices/i2c-0/0-0036 als_enable 0600 system system
+/sys/devices/i2c-0/0-0036 als_result 0400 system system


### PR DESCRIPTION
This requires the module definition of _sensors.default_ to be dropped from the zip file.
