### PR TITLE
Disable World Phone

### DIFF
--- a/overlay/packages/apps/Phone/res/values/config.xml
+++ b/overlay/packages/apps/Phone/res/values/config.xml
@@ -20,9 +20,6 @@
 <!-- Phone app resources that may need to be customized
      for different hardware or product builds. -->
 <resources>
-    <!-- Flag indicating if the phone is a world phone -->
-    <bool name="world_phone">true</bool>
-
     <!-- Determine whether calls to mute the microphone in PhoneUtils
          are routed through the android.media.AudioManager class (true) or through
          the com.android.internal.telephony.Phone interface (false). -->


### PR DESCRIPTION
world phone enable CDMA network switching removing it as yuga, the
only supported device is only GSM
