### PR TITLE
Add missing `source` command in build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ In the root of your Android code tree unzip the `SW_binaries_for_Xperia_Z_v2.zip
 You should now have directories named `vendor/sony/lagan` and `vendor/sony/c6603` in your tree.
 
 * `repo sync`
+* `source ./build/envsetup.sh`
 * `lunch full_c6603-userdebug`
 * `make`
 


### PR DESCRIPTION
If `source ./build/envsetup.sh` is not run, the `lunch` command
is not recognised.
